### PR TITLE
ci: improve GitHub Actions workflows and fix deprecated JVM flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,16 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Scala CI
 on:
   pull_request:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:
@@ -18,36 +21,37 @@ jobs:
             java: 8
           - os: ubuntu-latest
             java: 11
-    runs-on: ubuntu-latest
+          - os: ubuntu-latest
+            java: 17
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
+          cache: sbt
 
       - uses: sbt/setup-sbt@v1
 
-      - name: Create header and run scalafmt
-        run: sbt headerCreateAll scalafmtAll
+      - name: Create header and format check
+        run: sbt headerCreateAll scalafmtCheckAll
 
       - name: Build and Test with Coverage
         run: sbt clean coverage test coverageReport coverageAggregate
 
       - name: Upload coverage reports to Codecov
+        if: matrix.java == 11
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: eff3ct0/supabase-auth-scala
+          slug: eff3ct0/teckel
           files: target/scala-*/scoverage-report/scoverage.xml
           fail_ci_if_error: true
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-java-${{ matrix.java }}
           path: target/test-reports
-
-      # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository
-      #- name: Upload dependency graph
-      # uses: scalacenter/sbt-dependency-submission@ab086b50c947c9774b70f39fc7f6e20ca2706c91

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [master, main]
     tags: ["*"]
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -24,14 +28,15 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: eff3ct0/supabase-auth-scala
+          slug: eff3ct0/teckel
           files: target/scala-*/scoverage-report/scoverage.xml
           fail_ci_if_error: true
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-release
           path: target/test-reports
 
       - run: sbt ci-release

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -14,11 +14,12 @@ object BuildPlugin extends AutoPlugin {
     Seq(
       "-Xms8G",
       "-Xmx8G",
-      "-XX:MaxPermSize=4048M",
-      "-XX:+CMSClassUnloadingEnabled",
-      "-Duser.timezone=GMT",
-      "-XX:+PrintCommandLineFlags",
-      "-XX:+CMSClassUnloadingEnabled"
+      "-Duser.timezone=GMT"
+    )
+
+  lazy val moduleExports: Seq[String] =
+    Seq(
+      "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"
     )
 
   override def projectSettings: Seq[Setting[_]] = Seq(
@@ -26,13 +27,10 @@ object BuildPlugin extends AutoPlugin {
     organization       := "com.eff3ct",
     scalaVersion       := Version.Scala,
     crossScalaVersions := Vector(scalaVersion.value),
-    javacOptions := Seq(
-      "-g:none",
-      "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"
-    ),
-    run / javaOptions ++= localJvmSettings,
+    run / javaOptions ++= localJvmSettings ++ moduleExports,
     run / fork               := true,
     Test / fork              := true,
+    Test / javaOptions ++= moduleExports,
     Test / parallelExecution := false,
     headerLicense            := Some(Header.headerIOLicense),
     Compile / console / scalacOptions ~= (_.filterNot(


### PR DESCRIPTION
## Summary

- **CI workflow**: Add Java 17 to matrix, add SBT caching, change `scalafmtAll` → `scalafmtCheckAll` (check not auto-fix), add concurrency to cancel stale runs, upload Codecov only on Java 11, update `upload-artifact` v3→v4, add `permissions` block
- **Release workflow**: Update `upload-artifact` v3→v4, add `permissions` block, add `if: always()` for test upload
- **BuildPlugin**: Remove deprecated JVM flags (`-XX:MaxPermSize`, `-XX:+CMSClassUnloadingEnabled`, `-XX:+PrintCommandLineFlags`), move `--add-exports` from `javacOptions` to `javaOptions` where it belongs

## Test plan

- [ ] CI runs successfully on Java 8, 11, and 17
- [ ] SBT caching reduces build time on subsequent runs
- [ ] `scalafmtCheckAll` fails CI if code is not formatted (instead of silently fixing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)