### PR TITLE
build: update dependencies to latest stable versions

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,17 +1,17 @@
 object Version {
 
-  lazy val Scala: String   = "2.13.12"
+  lazy val Scala: String   = "2.13.16"
   lazy val Scala12: String = "2.12.18"
-  lazy val Spark: String   = "3.5.3"
+  lazy val Spark: String   = "3.5.5"
 
-  lazy val Cats: String       = "2.12.0"
-  lazy val CatsEffect: String = "3.5.5"
+  lazy val Cats: String       = "2.13.0"
+  lazy val CatsEffect: String = "3.5.7"
 
-  lazy val CirceYaml   = "1.15.0"
-  lazy val Circe       = "0.14.4"
-  lazy val Fs2: String = "3.9.3"
+  lazy val CirceYaml   = "1.16.0"
+  lazy val Circe       = "0.14.10"
+  lazy val Fs2: String = "3.11.0"
 
-  lazy val ScalaTest: String     = "3.2.9"
+  lazy val ScalaTest: String     = "3.2.19"
   lazy val HoldenVersion: String = "3.5.3_2.0.1"
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,11 @@
 /** Compiler */
-//addSbtPlugin("org.typelevel"      % "sbt-tpolecat"       % "0.5.2")
-addSbtPlugin("org.scoverage"      % "sbt-scoverage"      % "2.3.0")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"      % "2.3.1")
 addCompilerPlugin("com.olegpy"   %% "better-monadic-for" % "0.3.1")
-addCompilerPlugin("org.typelevel" % "kind-projector"     % "0.13.2" cross CrossVersion.full)
+addCompilerPlugin("org.typelevel" % "kind-projector"     % "0.13.3" cross CrossVersion.full)
 
 /** Build */
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly" % "2.3.0")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.5.4")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.10.0")
 
 /** Publish */


### PR DESCRIPTION
## Summary

Updates all dependencies to their latest stable versions:

| Library | Old | New |
|---------|-----|-----|
| Scala | 2.13.12 | 2.13.16 |
| Spark | 3.5.3 | 3.5.5 |
| Cats | 2.12.0 | 2.13.0 |
| Cats-Effect | 3.5.5 | 3.5.7 |
| Circe | 0.14.4 | 0.14.10 |
| circe-yaml | 1.15.0 | 1.16.0 |
| FS2 | 3.9.3 | 3.11.0 |
| ScalaTest | 3.2.9 | 3.2.19 |
| sbt-scoverage | 2.3.0 | 2.3.1 |
| sbt-scalafmt | 2.5.2 | 2.5.4 |
| kind-projector | 0.13.2 | 0.13.3 |

All are patch/minor updates within the same major version — no breaking changes expected.

## Test plan

- [ ] `sbt clean compile` succeeds
- [ ] `sbt clean coverage test coverageReport coverageAggregate` passes all tests
- [ ] `sbt cli/assembly` produces the uber JAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)