### PR TITLE
feat: add AddColumns, DropColumns, RenameColumns, CastColumns transformations

### DIFF
--- a/docs/etl/column-operations.yaml
+++ b/docs/etl/column-operations.yaml
@@ -1,0 +1,40 @@
+input:
+  - name: table1
+    format: csv
+    path: 'data/csv/example.csv'
+    options:
+      header: true
+      sep: '|'
+
+transformation:
+  - name: withNewCols
+    addColumns:
+      from: table1
+      columns:
+        - name: full_name
+          expression: "concat(col1, ' ', col2)"
+        - name: processed_at
+          expression: "current_timestamp()"
+  - name: renamed
+    renameColumns:
+      from: withNewCols
+      mappings:
+        col1: first_column
+        col2: second_column
+  - name: casted
+    castColumns:
+      from: renamed
+      columns:
+        - name: first_column
+          targetType: string
+  - name: cleaned
+    dropColumns:
+      from: casted
+      columns:
+        - processed_at
+
+output:
+  - name: cleaned
+    format: parquet
+    mode: overwrite
+    path: 'data/parquet/example'

--- a/model/src/main/scala/com/eff3ct/teckel/model/Source.scala
+++ b/model/src/main/scala/com/eff3ct/teckel/model/Source.scala
@@ -64,4 +64,16 @@ object Source {
   case class Limit(assetRef: AssetRef, count: Int) extends Transformation
 
   case class Relation(name: AssetRef, joinType: RelationType, on: List[Condition])
+
+  case class ColumnDef(name: Column, expression: String)
+
+  case class AddColumns(assetRef: AssetRef, columns: NonEmptyList[ColumnDef]) extends Transformation
+
+  case class DropColumns(assetRef: AssetRef, columns: NonEmptyList[Column]) extends Transformation
+
+  case class RenameColumns(assetRef: AssetRef, mappings: Map[Column, Column]) extends Transformation
+
+  case class CastColumn(name: Column, targetType: String)
+
+  case class CastColumns(assetRef: AssetRef, columns: NonEmptyList[CastColumn]) extends Transformation
 }

--- a/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
+++ b/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
@@ -27,7 +27,7 @@ package com.eff3ct.teckel.semantic.sources
 import cats.data.NonEmptyList
 import com.eff3ct.teckel.model.Context
 import com.eff3ct.teckel.model.Source._
-import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.functions.{expr, col}
 import org.apache.spark.sql.{DataFrame, RelationalGroupedDataset, SparkSession}
 
 object Debug {
@@ -47,6 +47,10 @@ object Debug {
       case s: Join    => join(s, df, others)
       case s: Distinct => distinct(df, s)
       case s: Limit    => limit(df, s)
+      case s: AddColumns    => addColumns(df, s)
+      case s: DropColumns   => dropColumns(df, s)
+      case s: RenameColumns => renameColumns(df, s)
+      case s: CastColumns   => castColumns(df, s)
     }
 
   /** Select */
@@ -86,6 +90,28 @@ object Debug {
   /** Limit */
   def limit[S <: Limit](df: DataFrame, source: S): DataFrame =
     df.limit(source.count)
+
+  /** AddColumns */
+  def addColumns[S <: AddColumns](df: DataFrame, source: S): DataFrame =
+    source.columns.foldLeft(df) { (acc, colDef) =>
+      acc.withColumn(colDef.name, expr(colDef.expression))
+    }
+
+  /** DropColumns */
+  def dropColumns[S <: DropColumns](df: DataFrame, source: S): DataFrame =
+    df.drop(source.columns.toList: _*)
+
+  /** RenameColumns */
+  def renameColumns[S <: RenameColumns](df: DataFrame, source: S): DataFrame =
+    source.mappings.foldLeft(df) { case (acc, (oldName, newName)) =>
+      acc.withColumnRenamed(oldName, newName)
+    }
+
+  /** CastColumns */
+  def castColumns[S <: CastColumns](df: DataFrame, source: S): DataFrame =
+    source.columns.foldLeft(df) { (acc, castCol) =>
+      acc.withColumn(castCol.name, col(castCol.name).cast(castCol.targetType))
+    }
 
   /** Join */
   def join[S <: Join](source: S, df: DataFrame, context: Context[DataFrame]): DataFrame = {

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
@@ -43,6 +43,10 @@ object operations {
       case j: JoinOp    => j.asJson
       case d: DistinctOp => d.asJson
       case l: LimitOp    => l.asJson
+      case a: AddColumnsOp    => a.asJson
+      case d: DropColumnsOp   => d.asJson
+      case r: RenameColumnsOp => r.asJson
+      case c: CastColumnsOp   => c.asJson
     }
 
   implicit val decodeEvent: Decoder[Operation] =
@@ -53,7 +57,11 @@ object operations {
       Decoder[OrderByOp].widen,
       Decoder[JoinOp].widen,
       Decoder[DistinctOp].widen,
-      Decoder[LimitOp].widen
+      Decoder[LimitOp].widen,
+      Decoder[AddColumnsOp].widen,
+      Decoder[DropColumnsOp].widen,
+      Decoder[RenameColumnsOp].widen,
+      Decoder[CastColumnsOp].widen
     ).reduceLeft(_ or _)
 
   case class SelectOp(from: String, columns: NonEmptyList[String]) extends Operation
@@ -66,6 +74,14 @@ object operations {
   case class JoinOp(left: String, right: NonEmptyList[Relation]) extends Operation
   case class DistinctOp(from: String, columns: Option[NonEmptyList[String]]) extends Operation
   case class LimitOp(from: String, count: Int)                               extends Operation
+
+  case class ColumnDef(name: String, expression: String)
+  case class CastColumnDef(name: String, targetType: String)
+
+  case class AddColumnsOp(from: String, columns: NonEmptyList[ColumnDef])     extends Operation
+  case class DropColumnsOp(from: String, columns: NonEmptyList[String])       extends Operation
+  case class RenameColumnsOp(from: String, mappings: Map[String, String])     extends Operation
+  case class CastColumnsOp(from: String, columns: NonEmptyList[CastColumnDef]) extends Operation
 
   case class Relation(name: String, relationType: String, on: List[String])
 

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
@@ -42,6 +42,10 @@ object transformation {
       case j: Join    => j.asJson
       case d: Distinct => d.asJson
       case l: Limit    => l.asJson
+      case a: AddColumns    => a.asJson
+      case d: DropColumns   => d.asJson
+      case r: RenameColumns => r.asJson
+      case c: CastColumns   => c.asJson
     }
 
   implicit val decodeEvent: Decoder[Transformation] =
@@ -52,7 +56,11 @@ object transformation {
       Decoder[OrderBy].widen,
       Decoder[Join].widen,
       Decoder[Distinct].widen,
-      Decoder[Limit].widen
+      Decoder[Limit].widen,
+      Decoder[AddColumns].widen,
+      Decoder[DropColumns].widen,
+      Decoder[RenameColumns].widen,
+      Decoder[CastColumns].widen
     ).reduceLeft(_ or _)
 
   case class Select(name: String, select: SelectOp)  extends Transformation
@@ -62,5 +70,10 @@ object transformation {
   case class Join(name: String, join: JoinOp)        extends Transformation
   case class Distinct(name: String, distinct: DistinctOp) extends Transformation
   case class Limit(name: String, limit: LimitOp)          extends Transformation
+
+  case class AddColumns(name: String, addColumns: AddColumnsOp)       extends Transformation
+  case class DropColumns(name: String, dropColumns: DropColumnsOp)    extends Transformation
+  case class RenameColumns(name: String, renameColumns: RenameColumnsOp) extends Transformation
+  case class CastColumns(name: String, castColumns: CastColumnsOp)    extends Transformation
 
 }

--- a/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
@@ -73,6 +73,30 @@ object Rewrite {
   def rewriteOp(item: Relation): Source.Relation =
     Source.Relation(item.name, item.relationType, item.on)
 
+  def rewriteOp(item: AddColumns): Asset =
+    Asset(
+      item.name,
+      Source.AddColumns(
+        item.addColumns.from,
+        item.addColumns.columns.map(c => Source.ColumnDef(c.name, c.expression))
+      )
+    )
+
+  def rewriteOp(item: DropColumns): Asset =
+    Asset(item.name, Source.DropColumns(item.dropColumns.from, item.dropColumns.columns))
+
+  def rewriteOp(item: RenameColumns): Asset =
+    Asset(item.name, Source.RenameColumns(item.renameColumns.from, item.renameColumns.mappings))
+
+  def rewriteOp(item: CastColumns): Asset =
+    Asset(
+      item.name,
+      Source.CastColumns(
+        item.castColumns.from,
+        item.castColumns.columns.map(c => Source.CastColumn(c.name, c.targetType))
+      )
+    )
+
   def rewrite(item: Transformation): Asset =
     item match {
       case s: Select  => rewriteOp(s)
@@ -82,6 +106,10 @@ object Rewrite {
       case s: Join    => rewriteOp(s)
       case s: Distinct => rewriteOp(s)
       case s: Limit    => rewriteOp(s)
+      case s: AddColumns    => rewriteOp(s)
+      case s: DropColumns   => rewriteOp(s)
+      case s: RenameColumns => rewriteOp(s)
+      case s: CastColumns   => rewriteOp(s)
     }
 
   def icontext(item: NonEmptyList[Input]): Context[Asset] =


### PR DESCRIPTION
## Summary

Adds 4 column-level transformations:
- **AddColumns**: add computed columns via Spark expressions
- **DropColumns**: remove columns by name
- **RenameColumns**: rename columns via a mapping
- **CastColumns**: cast columns to a target type

Full stack: model → serializer → semantic → example YAML

Closes #51

## YAML syntax

```yaml
transformation:
  - name: enriched
    addColumns:
      from: table1
      columns:
        - name: full_name
          expression: "concat(col1, ' ', col2)"
  - name: renamed
    renameColumns:
      from: enriched
      mappings:
        col1: first_column
  - name: casted
    castColumns:
      from: renamed
      columns:
        - name: first_column
          targetType: string
  - name: cleaned
    dropColumns:
      from: casted
      columns: [full_name]
```

## Test plan

- [ ] `sbt clean compile` succeeds
- [ ] AddColumns adds computed columns
- [ ] DropColumns removes specified columns
- [ ] RenameColumns renames correctly
- [ ] CastColumns changes column types