### PR TITLE
feat: add SQL expression transformation

### DIFF
--- a/docs/etl/sql.yaml
+++ b/docs/etl/sql.yaml
@@ -1,0 +1,29 @@
+input:
+  - name: customers
+    format: csv
+    path: 'data/csv/customers.csv'
+    options:
+      header: true
+      sep: '|'
+  - name: orders
+    format: csv
+    path: 'data/csv/orders.csv'
+    options:
+      header: true
+      sep: '|'
+
+transformation:
+  - name: customerOrders
+    sql:
+      from: customers
+      query: >
+        SELECT c.*, o.order_id, o.amount
+        FROM customers c
+        LEFT JOIN orders o ON c.id = o.customer_id
+        WHERE o.amount > 100
+
+output:
+  - name: customerOrders
+    format: parquet
+    mode: overwrite
+    path: 'data/parquet/customer_orders'

--- a/model/src/main/scala/com/eff3ct/teckel/model/Source.scala
+++ b/model/src/main/scala/com/eff3ct/teckel/model/Source.scala
@@ -76,4 +76,6 @@ object Source {
   case class CastColumn(name: Column, targetType: String)
 
   case class CastColumns(assetRef: AssetRef, columns: NonEmptyList[CastColumn]) extends Transformation
+
+  case class Sql(assetRef: AssetRef, query: String) extends Transformation
 }

--- a/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
+++ b/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
@@ -38,7 +38,9 @@ object Debug {
   def output[S <: Output]: DataFrame => DataFrame = identity[DataFrame]
 
   /** Transformation */
-  def transformation(source: Transformation, df: DataFrame, others: => Context[DataFrame]): DataFrame =
+  def transformation(source: Transformation, df: DataFrame, others: => Context[DataFrame])(implicit
+      S: SparkSession
+  ): DataFrame =
     source match {
       case s: Select  => select(df, s)
       case s: Where   => where(df, s)
@@ -51,6 +53,7 @@ object Debug {
       case s: DropColumns   => dropColumns(df, s)
       case s: RenameColumns => renameColumns(df, s)
       case s: CastColumns   => castColumns(df, s)
+      case s: Sql           => sql(s, df, others)
     }
 
   /** Select */
@@ -112,6 +115,15 @@ object Debug {
     source.columns.foldLeft(df) { (acc, castCol) =>
       acc.withColumn(castCol.name, col(castCol.name).cast(castCol.targetType))
     }
+
+  /** Sql */
+  def sql[S <: Sql](source: S, df: DataFrame, others: => Context[DataFrame])(implicit
+      S: SparkSession
+  ): DataFrame = {
+    others.foreach { case (name, otherDf) => otherDf.createOrReplaceTempView(name) }
+    df.createOrReplaceTempView(source.assetRef)
+    S.sql(source.query)
+  }
 
   /** Join */
   def join[S <: Join](source: S, df: DataFrame, context: Context[DataFrame]): DataFrame = {

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
@@ -47,6 +47,7 @@ object operations {
       case d: DropColumnsOp   => d.asJson
       case r: RenameColumnsOp => r.asJson
       case c: CastColumnsOp   => c.asJson
+      case s: SqlOp            => s.asJson
     }
 
   implicit val decodeEvent: Decoder[Operation] =
@@ -61,7 +62,8 @@ object operations {
       Decoder[AddColumnsOp].widen,
       Decoder[DropColumnsOp].widen,
       Decoder[RenameColumnsOp].widen,
-      Decoder[CastColumnsOp].widen
+      Decoder[CastColumnsOp].widen,
+      Decoder[SqlOp].widen
     ).reduceLeft(_ or _)
 
   case class SelectOp(from: String, columns: NonEmptyList[String]) extends Operation
@@ -82,6 +84,7 @@ object operations {
   case class DropColumnsOp(from: String, columns: NonEmptyList[String])       extends Operation
   case class RenameColumnsOp(from: String, mappings: Map[String, String])     extends Operation
   case class CastColumnsOp(from: String, columns: NonEmptyList[CastColumnDef]) extends Operation
+  case class SqlOp(from: String, query: String)                                extends Operation
 
   case class Relation(name: String, relationType: String, on: List[String])
 

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
@@ -46,6 +46,7 @@ object transformation {
       case d: DropColumns   => d.asJson
       case r: RenameColumns => r.asJson
       case c: CastColumns   => c.asJson
+      case s: SqlExpr       => s.asJson
     }
 
   implicit val decodeEvent: Decoder[Transformation] =
@@ -60,7 +61,8 @@ object transformation {
       Decoder[AddColumns].widen,
       Decoder[DropColumns].widen,
       Decoder[RenameColumns].widen,
-      Decoder[CastColumns].widen
+      Decoder[CastColumns].widen,
+      Decoder[SqlExpr].widen
     ).reduceLeft(_ or _)
 
   case class Select(name: String, select: SelectOp)  extends Transformation
@@ -75,5 +77,6 @@ object transformation {
   case class DropColumns(name: String, dropColumns: DropColumnsOp)    extends Transformation
   case class RenameColumns(name: String, renameColumns: RenameColumnsOp) extends Transformation
   case class CastColumns(name: String, castColumns: CastColumnsOp)    extends Transformation
+  case class SqlExpr(name: String, sql: SqlOp)                        extends Transformation
 
 }

--- a/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
@@ -97,6 +97,9 @@ object Rewrite {
       )
     )
 
+  def rewriteOp(item: SqlExpr): Asset =
+    Asset(item.name, Source.Sql(item.sql.from, item.sql.query))
+
   def rewrite(item: Transformation): Asset =
     item match {
       case s: Select  => rewriteOp(s)
@@ -110,6 +113,7 @@ object Rewrite {
       case s: DropColumns   => rewriteOp(s)
       case s: RenameColumns => rewriteOp(s)
       case s: CastColumns   => rewriteOp(s)
+      case s: SqlExpr       => rewriteOp(s)
     }
 
   def icontext(item: NonEmptyList[Input]): Context[Asset] =


### PR DESCRIPTION
## Summary

- Adds `Sql` transformation type: execute raw SQL queries as an escape hatch for complex logic
- Registers all context DataFrames as temp views, then runs `spark.sql(query)`
- Full stack: model → serializer → semantic → example YAML

Closes #42

## YAML syntax

```yaml
transformation:
  - name: result
    sql:
      from: customers
      query: >
        SELECT c.*, o.amount
        FROM customers c
        LEFT JOIN orders o ON c.id = o.customer_id
        WHERE o.amount > 100
```