### PR TITLE
feat: add Union, Intersect, Except set operations

### DIFF
--- a/docs/etl/union.yaml
+++ b/docs/etl/union.yaml
@@ -1,0 +1,25 @@
+input:
+  - name: table1
+    format: csv
+    path: 'data/csv/example1.csv'
+    options:
+      header: true
+      sep: '|'
+  - name: table2
+    format: csv
+    path: 'data/csv/example2.csv'
+    options:
+      header: true
+      sep: '|'
+
+transformation:
+  - name: combined
+    union:
+      sources: [table1, table2]
+      all: true
+
+output:
+  - name: combined
+    format: parquet
+    mode: overwrite
+    path: 'data/parquet/combined'

--- a/model/src/main/scala/com/eff3ct/teckel/model/Source.scala
+++ b/model/src/main/scala/com/eff3ct/teckel/model/Source.scala
@@ -78,4 +78,10 @@ object Source {
   case class CastColumns(assetRef: AssetRef, columns: NonEmptyList[CastColumn]) extends Transformation
 
   case class Sql(assetRef: AssetRef, query: String) extends Transformation
+  case class Union(assetRef: AssetRef, others: NonEmptyList[AssetRef], all: Boolean) extends Transformation
+
+  case class Intersect(assetRef: AssetRef, others: NonEmptyList[AssetRef], all: Boolean)
+      extends Transformation
+
+  case class Except(assetRef: AssetRef, other: AssetRef, all: Boolean) extends Transformation
 }

--- a/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
+++ b/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
@@ -54,6 +54,9 @@ object Debug {
       case s: RenameColumns => renameColumns(df, s)
       case s: CastColumns   => castColumns(df, s)
       case s: Sql           => sql(s, df, others)
+      case s: Union         => union(s, df, others)
+      case s: Intersect     => intersect(s, df, others)
+      case s: Except        => except(s, df, others)
     }
 
   /** Select */
@@ -123,6 +126,26 @@ object Debug {
     others.foreach { case (name, otherDf) => otherDf.createOrReplaceTempView(name) }
     df.createOrReplaceTempView(source.assetRef)
     S.sql(source.query)
+  /** Union */
+  def union[S <: Union](source: S, df: DataFrame, context: Context[DataFrame]): DataFrame = {
+    val otherDfs = source.others.map(ref => context(ref))
+    otherDfs.foldLeft(df) { (acc, other) =>
+      if (source.all) acc.unionAll(other) else acc.union(other)
+    }
+  }
+
+  /** Intersect */
+  def intersect[S <: Intersect](source: S, df: DataFrame, context: Context[DataFrame]): DataFrame = {
+    val otherDfs = source.others.map(ref => context(ref))
+    otherDfs.foldLeft(df) { (acc, other) =>
+      if (source.all) acc.intersectAll(other) else acc.intersect(other)
+    }
+  }
+
+  /** Except */
+  def except[S <: Except](source: S, df: DataFrame, context: Context[DataFrame]): DataFrame = {
+    val other = context(source.other)
+    if (source.all) df.exceptAll(other) else df.except(other)
   }
 
   /** Join */

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
@@ -48,6 +48,9 @@ object operations {
       case r: RenameColumnsOp => r.asJson
       case c: CastColumnsOp   => c.asJson
       case s: SqlOp            => s.asJson
+      case u: UnionOp         => u.asJson
+      case i: IntersectOp     => i.asJson
+      case e: ExceptOp        => e.asJson
     }
 
   implicit val decodeEvent: Decoder[Operation] =
@@ -64,6 +67,9 @@ object operations {
       Decoder[RenameColumnsOp].widen,
       Decoder[CastColumnsOp].widen,
       Decoder[SqlOp].widen
+      Decoder[UnionOp].widen,
+      Decoder[IntersectOp].widen,
+      Decoder[ExceptOp].widen
     ).reduceLeft(_ or _)
 
   case class SelectOp(from: String, columns: NonEmptyList[String]) extends Operation
@@ -85,6 +91,10 @@ object operations {
   case class RenameColumnsOp(from: String, mappings: Map[String, String])     extends Operation
   case class CastColumnsOp(from: String, columns: NonEmptyList[CastColumnDef]) extends Operation
   case class SqlOp(from: String, query: String)                                extends Operation
+
+  case class UnionOp(sources: NonEmptyList[String], all: Option[Boolean])     extends Operation
+  case class IntersectOp(sources: NonEmptyList[String], all: Option[Boolean]) extends Operation
+  case class ExceptOp(left: String, right: String, all: Option[Boolean])      extends Operation
 
   case class Relation(name: String, relationType: String, on: List[String])
 

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
@@ -47,6 +47,9 @@ object transformation {
       case r: RenameColumns => r.asJson
       case c: CastColumns   => c.asJson
       case s: SqlExpr       => s.asJson
+      case u: UnionT        => u.asJson
+      case i: IntersectT    => i.asJson
+      case e: ExceptT       => e.asJson
     }
 
   implicit val decodeEvent: Decoder[Transformation] =
@@ -63,6 +66,9 @@ object transformation {
       Decoder[RenameColumns].widen,
       Decoder[CastColumns].widen,
       Decoder[SqlExpr].widen
+      Decoder[UnionT].widen,
+      Decoder[IntersectT].widen,
+      Decoder[ExceptT].widen
     ).reduceLeft(_ or _)
 
   case class Select(name: String, select: SelectOp)  extends Transformation
@@ -78,5 +84,9 @@ object transformation {
   case class RenameColumns(name: String, renameColumns: RenameColumnsOp) extends Transformation
   case class CastColumns(name: String, castColumns: CastColumnsOp)    extends Transformation
   case class SqlExpr(name: String, sql: SqlOp)                        extends Transformation
+
+  case class UnionT(name: String, union: UnionOp)            extends Transformation
+  case class IntersectT(name: String, intersect: IntersectOp) extends Transformation
+  case class ExceptT(name: String, except: ExceptOp)          extends Transformation
 
 }

--- a/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
@@ -99,6 +99,30 @@ object Rewrite {
 
   def rewriteOp(item: SqlExpr): Asset =
     Asset(item.name, Source.Sql(item.sql.from, item.sql.query))
+  def rewriteOp(item: UnionT): Asset = {
+    val head = item.union.sources.head
+    val tail = item.union.sources.tail
+    Asset(
+      item.name,
+      Source.Union(head, NonEmptyList.fromListUnsafe(tail), item.union.all.getOrElse(false))
+    )
+  }
+
+  def rewriteOp(item: IntersectT): Asset = {
+    val head = item.intersect.sources.head
+    val tail = item.intersect.sources.tail
+    Asset(
+      item.name,
+      Source
+        .Intersect(head, NonEmptyList.fromListUnsafe(tail), item.intersect.all.getOrElse(false))
+    )
+  }
+
+  def rewriteOp(item: ExceptT): Asset =
+    Asset(
+      item.name,
+      Source.Except(item.except.left, item.except.right, item.except.all.getOrElse(false))
+    )
 
   def rewrite(item: Transformation): Asset =
     item match {
@@ -114,6 +138,9 @@ object Rewrite {
       case s: RenameColumns => rewriteOp(s)
       case s: CastColumns   => rewriteOp(s)
       case s: SqlExpr       => rewriteOp(s)
+      case s: UnionT        => rewriteOp(s)
+      case s: IntersectT    => rewriteOp(s)
+      case s: ExceptT       => rewriteOp(s)
     }
 
   def icontext(item: NonEmptyList[Input]): Context[Asset] =


### PR DESCRIPTION
## Summary

- Adds `Union`, `Intersect`, `Except` set operations
- Supports `all: true/false` for dedup vs keep-all semantics
- Union/Intersect support multiple sources via `NonEmptyList`
- Full stack: model → serializer → semantic → example YAML

Closes #40

## YAML syntax

```yaml
transformation:
  - name: combined
    union:
      sources: [table1, table2]
      all: true
  - name: common
    intersect:
      sources: [table1, table2]
  - name: diff
    except:
      left: table1
      right: table2
```