### PR TITLE
feat: add Window function transformation

### DIFF
--- a/docs/etl/window.yaml
+++ b/docs/etl/window.yaml
@@ -1,0 +1,27 @@
+input:
+  - name: employees
+    format: csv
+    path: 'data/csv/employees.csv'
+    options:
+      header: true
+      sep: '|'
+
+transformation:
+  - name: ranked
+    window:
+      from: employees
+      partitionBy: [department]
+      orderBy: [salary]
+      functions:
+        - expression: "row_number()"
+          alias: row_num
+        - expression: "rank()"
+          alias: salary_rank
+        - expression: "sum(salary)"
+          alias: dept_total_salary
+
+output:
+  - name: ranked
+    format: parquet
+    mode: overwrite
+    path: 'data/parquet/ranked_employees'

--- a/model/src/main/scala/com/eff3ct/teckel/model/Source.scala
+++ b/model/src/main/scala/com/eff3ct/teckel/model/Source.scala
@@ -84,4 +84,12 @@ object Source {
       extends Transformation
 
   case class Except(assetRef: AssetRef, other: AssetRef, all: Boolean) extends Transformation
+  case class WindowFunc(expression: String, alias: Column)
+
+  case class Window(
+      assetRef: AssetRef,
+      partitionBy: NonEmptyList[Column],
+      orderBy: Option[NonEmptyList[Column]],
+      functions: NonEmptyList[WindowFunc]
+  ) extends Transformation
 }

--- a/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
+++ b/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
@@ -27,6 +27,7 @@ package com.eff3ct.teckel.semantic.sources
 import cats.data.NonEmptyList
 import com.eff3ct.teckel.model.Context
 import com.eff3ct.teckel.model.Source._
+import org.apache.spark.sql.expressions.{Window => SparkWindow}
 import org.apache.spark.sql.functions.{expr, col}
 import org.apache.spark.sql.{DataFrame, RelationalGroupedDataset, SparkSession}
 
@@ -57,6 +58,7 @@ object Debug {
       case s: Union         => union(s, df, others)
       case s: Intersect     => intersect(s, df, others)
       case s: Except        => except(s, df, others)
+      case s: Window        => window(df, s)
     }
 
   /** Select */
@@ -146,6 +148,20 @@ object Debug {
   def except[S <: Except](source: S, df: DataFrame, context: Context[DataFrame]): DataFrame = {
     val other = context(source.other)
     if (source.all) df.exceptAll(other) else df.except(other)
+  }
+
+  /** Window */
+  def window[S <: Window](df: DataFrame, source: S): DataFrame = {
+    val partitionCols = source.partitionBy.toList.map(col)
+    val windowSpec = source.orderBy match {
+      case Some(orderCols) =>
+        SparkWindow.partitionBy(partitionCols: _*).orderBy(orderCols.toList.map(col): _*)
+      case None =>
+        SparkWindow.partitionBy(partitionCols: _*)
+    }
+    source.functions.foldLeft(df) { (acc, func) =>
+      acc.withColumn(func.alias, expr(func.expression).over(windowSpec))
+    }
   }
 
   /** Join */

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
@@ -51,6 +51,7 @@ object operations {
       case u: UnionOp         => u.asJson
       case i: IntersectOp     => i.asJson
       case e: ExceptOp        => e.asJson
+      case w: WindowOp        => w.asJson
     }
 
   implicit val decodeEvent: Decoder[Operation] =
@@ -70,6 +71,7 @@ object operations {
       Decoder[UnionOp].widen,
       Decoder[IntersectOp].widen,
       Decoder[ExceptOp].widen
+      Decoder[WindowOp].widen
     ).reduceLeft(_ or _)
 
   case class SelectOp(from: String, columns: NonEmptyList[String]) extends Operation
@@ -95,6 +97,15 @@ object operations {
   case class UnionOp(sources: NonEmptyList[String], all: Option[Boolean])     extends Operation
   case class IntersectOp(sources: NonEmptyList[String], all: Option[Boolean]) extends Operation
   case class ExceptOp(left: String, right: String, all: Option[Boolean])      extends Operation
+
+  case class WindowFuncDef(expression: String, alias: String)
+
+  case class WindowOp(
+      from: String,
+      partitionBy: NonEmptyList[String],
+      orderBy: Option[NonEmptyList[String]],
+      functions: NonEmptyList[WindowFuncDef]
+  ) extends Operation
 
   case class Relation(name: String, relationType: String, on: List[String])
 

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
@@ -50,6 +50,7 @@ object transformation {
       case u: UnionT        => u.asJson
       case i: IntersectT    => i.asJson
       case e: ExceptT       => e.asJson
+      case w: WindowT       => w.asJson
     }
 
   implicit val decodeEvent: Decoder[Transformation] =
@@ -69,6 +70,7 @@ object transformation {
       Decoder[UnionT].widen,
       Decoder[IntersectT].widen,
       Decoder[ExceptT].widen
+      Decoder[WindowT].widen
     ).reduceLeft(_ or _)
 
   case class Select(name: String, select: SelectOp)  extends Transformation
@@ -88,5 +90,7 @@ object transformation {
   case class UnionT(name: String, union: UnionOp)            extends Transformation
   case class IntersectT(name: String, intersect: IntersectOp) extends Transformation
   case class ExceptT(name: String, except: ExceptOp)          extends Transformation
+
+  case class WindowT(name: String, window: WindowOp) extends Transformation
 
 }

--- a/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
@@ -122,6 +122,15 @@ object Rewrite {
     Asset(
       item.name,
       Source.Except(item.except.left, item.except.right, item.except.all.getOrElse(false))
+  def rewriteOp(item: WindowT): Asset =
+    Asset(
+      item.name,
+      Source.Window(
+        item.window.from,
+        item.window.partitionBy,
+        item.window.orderBy,
+        item.window.functions.map(f => Source.WindowFunc(f.expression, f.alias))
+      )
     )
 
   def rewrite(item: Transformation): Asset =
@@ -141,6 +150,7 @@ object Rewrite {
       case s: UnionT        => rewriteOp(s)
       case s: IntersectT    => rewriteOp(s)
       case s: ExceptT       => rewriteOp(s)
+      case s: WindowT       => rewriteOp(s)
     }
 
   def icontext(item: NonEmptyList[Input]): Context[Asset] =


### PR DESCRIPTION
## Summary

- Adds `Window` transformation: partition, order, and apply window functions
- Supports any Spark SQL window expression (row_number, rank, lag, lead, sum, etc.)
- Full stack: model → serializer → semantic → example YAML

Closes #39

## YAML syntax

```yaml
transformation:
  - name: ranked
    window:
      from: employees
      partitionBy: [department]
      orderBy: [salary]
      functions:
        - expression: "row_number()"
          alias: row_num
        - expression: "rank()"
          alias: salary_rank
```