### PR TITLE
feat: add Flatten transformation for nested structs and arrays

### DIFF
--- a/docs/etl/flatten.yaml
+++ b/docs/etl/flatten.yaml
@@ -1,0 +1,17 @@
+input:
+  - name: nested
+    format: json
+    path: 'data/json/nested.json'
+
+transformation:
+  - name: flat
+    flatten:
+      from: nested
+      separator: '_'
+      explodeArrays: true
+
+output:
+  - name: flat
+    format: parquet
+    mode: overwrite
+    path: 'data/parquet/flat'

--- a/model/src/main/scala/com/eff3ct/teckel/model/Source.scala
+++ b/model/src/main/scala/com/eff3ct/teckel/model/Source.scala
@@ -92,4 +92,7 @@ object Source {
       orderBy: Option[NonEmptyList[Column]],
       functions: NonEmptyList[WindowFunc]
   ) extends Transformation
+
+  case class Flatten(assetRef: AssetRef, separator: Option[String], explodeArrays: Option[Boolean])
+      extends Transformation
 }

--- a/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
+++ b/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
@@ -28,8 +28,9 @@ import cats.data.NonEmptyList
 import com.eff3ct.teckel.model.Context
 import com.eff3ct.teckel.model.Source._
 import org.apache.spark.sql.expressions.{Window => SparkWindow}
-import org.apache.spark.sql.functions.{expr, col}
-import org.apache.spark.sql.{DataFrame, RelationalGroupedDataset, SparkSession}
+import org.apache.spark.sql.functions.{expr, col, explode_outer}
+import org.apache.spark.sql.types.{StructType, ArrayType}
+import org.apache.spark.sql.{Column, DataFrame, RelationalGroupedDataset, SparkSession}
 
 object Debug {
 
@@ -59,6 +60,7 @@ object Debug {
       case s: Intersect     => intersect(s, df, others)
       case s: Except        => except(s, df, others)
       case s: Window        => window(df, s)
+      case s: Flatten       => flatten(df, s)
     }
 
   /** Select */
@@ -162,6 +164,31 @@ object Debug {
     source.functions.foldLeft(df) { (acc, func) =>
       acc.withColumn(func.alias, expr(func.expression).over(windowSpec))
     }
+  }
+
+  /** Flatten */
+  def flatten[S <: Flatten](df: DataFrame, source: S): DataFrame = {
+    val sep = source.separator.getOrElse("_")
+    val explode = source.explodeArrays.getOrElse(true)
+
+    def flattenSchema(schema: StructType, prefix: String): Array[Column] =
+      schema.fields.flatMap { field =>
+        val colName = if (prefix.isEmpty) field.name else s"$prefix$sep${field.name}"
+        field.dataType match {
+          case st: StructType =>
+            flattenSchema(st, colName)
+          case _: ArrayType if explode =>
+            Array(explode_outer(col(
+              if (prefix.isEmpty) field.name else s"$prefix.${field.name}"
+            )).as(colName))
+          case _ =>
+            Array(col(
+              if (prefix.isEmpty) field.name else s"$prefix.${field.name}"
+            ).as(colName))
+        }
+      }
+
+    df.select(flattenSchema(df.schema, ""): _*)
   }
 
   /** Join */

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
@@ -52,6 +52,7 @@ object operations {
       case i: IntersectOp     => i.asJson
       case e: ExceptOp        => e.asJson
       case w: WindowOp        => w.asJson
+      case f: FlattenOp       => f.asJson
     }
 
   implicit val decodeEvent: Decoder[Operation] =
@@ -71,7 +72,8 @@ object operations {
       Decoder[UnionOp].widen,
       Decoder[IntersectOp].widen,
       Decoder[ExceptOp].widen
-      Decoder[WindowOp].widen
+      Decoder[WindowOp].widen,
+      Decoder[FlattenOp].widen
     ).reduceLeft(_ or _)
 
   case class SelectOp(from: String, columns: NonEmptyList[String]) extends Operation
@@ -106,6 +108,9 @@ object operations {
       orderBy: Option[NonEmptyList[String]],
       functions: NonEmptyList[WindowFuncDef]
   ) extends Operation
+
+  case class FlattenOp(from: String, separator: Option[String], explodeArrays: Option[Boolean])
+      extends Operation
 
   case class Relation(name: String, relationType: String, on: List[String])
 

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
@@ -51,6 +51,7 @@ object transformation {
       case i: IntersectT    => i.asJson
       case e: ExceptT       => e.asJson
       case w: WindowT       => w.asJson
+      case f: FlattenT      => f.asJson
     }
 
   implicit val decodeEvent: Decoder[Transformation] =
@@ -70,7 +71,8 @@ object transformation {
       Decoder[UnionT].widen,
       Decoder[IntersectT].widen,
       Decoder[ExceptT].widen
-      Decoder[WindowT].widen
+      Decoder[WindowT].widen,
+      Decoder[FlattenT].widen
     ).reduceLeft(_ or _)
 
   case class Select(name: String, select: SelectOp)  extends Transformation
@@ -92,5 +94,7 @@ object transformation {
   case class ExceptT(name: String, except: ExceptOp)          extends Transformation
 
   case class WindowT(name: String, window: WindowOp) extends Transformation
+
+  case class FlattenT(name: String, flatten: FlattenOp) extends Transformation
 
 }

--- a/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
@@ -122,6 +122,9 @@ object Rewrite {
     Asset(
       item.name,
       Source.Except(item.except.left, item.except.right, item.except.all.getOrElse(false))
+  def rewriteOp(item: FlattenT): Asset =
+    Asset(item.name, Source.Flatten(item.flatten.from, item.flatten.separator, item.flatten.explodeArrays))
+
   def rewriteOp(item: WindowT): Asset =
     Asset(
       item.name,
@@ -151,6 +154,7 @@ object Rewrite {
       case s: IntersectT    => rewriteOp(s)
       case s: ExceptT       => rewriteOp(s)
       case s: WindowT       => rewriteOp(s)
+      case s: FlattenT      => rewriteOp(s)
     }
 
   def icontext(item: NonEmptyList[Input]): Context[Asset] =


### PR DESCRIPTION
## Summary
- Adds `Flatten` transformation: recursively expands nested structs and optionally explodes arrays
- Configurable separator and explodeArrays flag
- Full stack: model → serializer → semantic → example YAML

Closes #57