### PR TITLE
feat: add dry-run / explain mode for pipeline debugging

### DIFF
--- a/api/src/main/scala/com/eff3ct/teckel/api/DryRun.scala
+++ b/api/src/main/scala/com/eff3ct/teckel/api/DryRun.scala
@@ -1,0 +1,126 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Rafael Fernandez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.eff3ct.teckel.api
+
+import com.eff3ct.teckel.model.{Asset, AssetRef, Context}
+import com.eff3ct.teckel.model.Source._
+import com.eff3ct.teckel.serializer.Serializer
+import com.eff3ct.teckel.serializer.model.etl._
+import com.eff3ct.teckel.transform.Rewrite
+
+object DryRun {
+
+  case class PlanStep(name: String, stepType: String, details: String, dependsOn: List[String])
+
+  def explain(yamlContent: String): Either[Throwable, String] =
+    Serializer[ETL].decode(yamlContent).map { etl =>
+      val context = Rewrite.rewrite(etl)
+      formatPlan(context)
+    }
+
+  private def formatPlan(context: Context[Asset]): String = {
+    val steps           = context.map { case (ref, asset) => planStep(ref, asset) }.toList
+    val inputs          = steps.filter(_.stepType == "INPUT")
+    val transformations = steps.filter(s => s.stepType != "INPUT" && s.stepType != "OUTPUT")
+    val outputs         = steps.filter(_.stepType == "OUTPUT")
+
+    val sb = new StringBuilder
+    sb.append("=== Pipeline Execution Plan ===\n\n")
+
+    sb.append("--- Inputs ---\n")
+    inputs.foreach { s =>
+      sb.append(s"  [${s.name}] ${s.details}\n")
+    }
+
+    if (transformations.nonEmpty) {
+      sb.append("\n--- Transformations ---\n")
+      transformations.foreach { s =>
+        val deps = if (s.dependsOn.nonEmpty) s" (from: ${s.dependsOn.mkString(", ")})" else ""
+        sb.append(s"  [${s.name}] ${s.stepType}$deps -> ${s.details}\n")
+      }
+    }
+
+    sb.append("\n--- Outputs ---\n")
+    outputs.foreach { s =>
+      val deps = if (s.dependsOn.nonEmpty) s" (from: ${s.dependsOn.mkString(", ")})" else ""
+      sb.append(s"  [${s.name}]$deps -> ${s.details}\n")
+    }
+
+    sb.append(
+      s"\nTotal: ${inputs.size} inputs, ${transformations.size} transformations, ${outputs.size} outputs\n"
+    )
+    sb.toString
+  }
+
+  private def planStep(ref: AssetRef, asset: Asset): PlanStep =
+    asset.source match {
+      case s: Input =>
+        PlanStep(ref, "INPUT", s"format=${s.format}, path=${s.sourceRef}", Nil)
+      case s: Output =>
+        PlanStep(
+          ref,
+          "OUTPUT",
+          s"format=${s.format}, mode=${s.mode}, path=${s.sourceRef}",
+          List(s.assetRef)
+        )
+      case s: Select =>
+        PlanStep(
+          ref,
+          "SELECT",
+          s"columns=[${s.columns.toList.mkString(", ")}]",
+          List(s.assetRef)
+        )
+      case s: Where =>
+        PlanStep(ref, "WHERE", s"condition=${s.condition}", List(s.assetRef))
+      case s: GroupBy =>
+        PlanStep(
+          ref,
+          "GROUP_BY",
+          s"by=[${s.by.toList.mkString(", ")}], agg=[${s.aggregate.toList.mkString(", ")}]",
+          List(s.assetRef)
+        )
+      case s: OrderBy =>
+        PlanStep(
+          ref,
+          "ORDER_BY",
+          s"by=[${s.by.toList.mkString(", ")}], order=${s.order.getOrElse("asc")}",
+          List(s.assetRef)
+        )
+      case s: Join =>
+        PlanStep(
+          ref,
+          "JOIN",
+          s"tables=[${s.others.toList.map(_.name).mkString(", ")}]",
+          s.assetRef :: s.others.toList.map(_.name)
+        )
+      case _: Transformation =>
+        PlanStep(
+          ref,
+          "TRANSFORMATION",
+          "custom",
+          List(asset.source.asInstanceOf[Transformation].assetRef)
+        )
+    }
+}

--- a/cli/src/main/scala/com/eff3ct/teckel/app/Main.scala
+++ b/cli/src/main/scala/com/eff3ct/teckel/app/Main.scala
@@ -25,6 +25,7 @@
 package com.eff3ct.teckel.app
 
 import cats.effect.{Async, ExitCode, IO}
+import com.eff3ct.teckel.api.DryRun
 import com.eff3ct.teckel.api.core.Run
 import com.eff3ct.teckel.api.spark.SparkETL
 import com.eff3ct.teckel.io.Console
@@ -38,8 +39,23 @@ object Main extends SparkETL {
 
   override def runIO(
       args: List[String]
-  )(implicit spark: SparkSession, logger: slf4j.Logger): IO[ExitCode] =
-    execute[IO, Unit](args).compile.drain.as(ExitCode.Success)
+  )(implicit spark: SparkSession, logger: slf4j.Logger): IO[ExitCode] = {
+    val commands = Console.parseCommand(args)
+    commands match {
+      case Console.FILE(file, true) =>
+        // Dry run mode
+        IO {
+          val content = scala.io.Source.fromFile(file).mkString
+          DryRun.explain(content) match {
+            case Right(plan) => println(plan)
+            case Left(err)   => println(s"Error: ${err.getMessage}")
+          }
+          ExitCode.Success
+        }
+      case _ =>
+        execute[IO, Unit](args).compile.drain.as(ExitCode.Success)
+    }
+  }
 
   def execute[F[_]: Files: Async: Run, O: EvalContext](args: List[String]): fs2.Stream[F, O] =
     for {

--- a/cli/src/main/scala/com/eff3ct/teckel/io/Console.scala
+++ b/cli/src/main/scala/com/eff3ct/teckel/io/Console.scala
@@ -32,10 +32,11 @@ import fs2.io.file.Files
 object Console {
 
   sealed trait Commands
-  case class STDIN(variables: Map[String, String])                extends Commands
-  case class FILE(file: String, variables: Map[String, String])   extends Commands
+  case class STDIN(variables: Map[String, String])                                    extends Commands
+  case class FILE(file: String, variables: Map[String, String], dryRun: Boolean = false) extends Commands
 
   def parseCommand(args: List[String]): Commands = {
+    val dryRun = args.contains("--dry-run")
     val variables = args
       .filter(_.startsWith("-D"))
       .map(_.stripPrefix("-D"))
@@ -49,21 +50,21 @@ object Console {
       }
       .toMap
 
-    val filteredArgs = args.filterNot(_.startsWith("-D"))
+    val filteredArgs = args.filterNot(a => a.startsWith("-D") || a == "--dry-run")
     filteredArgs match {
       case "-c" :: Nil         => STDIN(variables)
-      case "-f" :: file :: Nil => FILE(file, variables)
+      case "-f" :: file :: Nil => FILE(file, variables, dryRun)
       case _ =>
         throw new IllegalArgumentException(
-          s"Invalid arguments: ${args.mkString(" ")}. Usage: -f <file> [-D key=value ...] or -c [-D key=value ...]"
+          s"Invalid arguments: ${args.mkString(" ")}. Usage: -f <file> [--dry-run] [-D key=value ...] or -c [-D key=value ...]"
         )
     }
   }
 
   def eval[F[_]: Files: Async: Run, O: EvalContext](commands: Commands): fs2.Stream[F, O] =
     commands match {
-      case STDIN(variables)      => Parser.parseStdin[F, O](variables)
-      case FILE(file, variables) => Parser.parseFile[F, O](file, variables)
+      case STDIN(variables)         => Parser.parseStdin[F, O](variables)
+      case FILE(file, variables, _) => Parser.parseFile[F, O](file, variables)
     }
 
   def command[F[_]: Sync](args: List[String]): fs2.Stream[F, Commands] =


### PR DESCRIPTION
## Summary
- Adds `--dry-run` CLI flag that validates YAML and prints execution plan without running
- New `DryRun.explain()` in api module that parses YAML, builds asset DAG, and formats a human-readable plan
- Shows inputs, transformations with dependencies, and outputs

Closes #61