### PR TITLE
feat: add Split transformation for conditional output routing

### DIFF
--- a/docs/etl/split.yaml
+++ b/docs/etl/split.yaml
@@ -1,0 +1,22 @@
+input:
+  - name: apiResults
+    format: parquet
+    path: 'data/parquet/api_results'
+
+transformation:
+  - name: splitByStatus
+    split:
+      from: apiResults
+      condition: 'status_code = 200'
+      pass: successRecords
+      fail: failedRecords
+
+output:
+  - name: successRecords
+    format: delta
+    mode: append
+    path: 'data/delta/success'
+  - name: failedRecords
+    format: delta
+    mode: append
+    path: 'data/delta/dead_letter'

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
@@ -53,6 +53,7 @@ object operations {
       case e: ExceptOp        => e.asJson
       case w: WindowOp        => w.asJson
       case f: FlattenOp       => f.asJson
+      case s: SplitOp         => s.asJson
     }
 
   implicit val decodeEvent: Decoder[Operation] =
@@ -73,7 +74,8 @@ object operations {
       Decoder[IntersectOp].widen,
       Decoder[ExceptOp].widen
       Decoder[WindowOp].widen,
-      Decoder[FlattenOp].widen
+      Decoder[FlattenOp].widen,
+      Decoder[SplitOp].widen
     ).reduceLeft(_ or _)
 
   case class SelectOp(from: String, columns: NonEmptyList[String]) extends Operation
@@ -111,6 +113,8 @@ object operations {
 
   case class FlattenOp(from: String, separator: Option[String], explodeArrays: Option[Boolean])
       extends Operation
+
+  case class SplitOp(from: String, condition: String, pass: String, fail: String) extends Operation
 
   case class Relation(name: String, relationType: String, on: List[String])
 

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
@@ -52,6 +52,7 @@ object transformation {
       case e: ExceptT       => e.asJson
       case w: WindowT       => w.asJson
       case f: FlattenT      => f.asJson
+      case s: SplitT        => s.asJson
     }
 
   implicit val decodeEvent: Decoder[Transformation] =
@@ -72,7 +73,8 @@ object transformation {
       Decoder[IntersectT].widen,
       Decoder[ExceptT].widen
       Decoder[WindowT].widen,
-      Decoder[FlattenT].widen
+      Decoder[FlattenT].widen,
+      Decoder[SplitT].widen
     ).reduceLeft(_ or _)
 
   case class Select(name: String, select: SelectOp)  extends Transformation
@@ -96,5 +98,7 @@ object transformation {
   case class WindowT(name: String, window: WindowOp) extends Transformation
 
   case class FlattenT(name: String, flatten: FlattenOp) extends Transformation
+
+  case class SplitT(name: String, split: SplitOp) extends Transformation
 
 }

--- a/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
@@ -178,11 +178,17 @@ object Rewrite {
   def tcontext(item: Option[NonEmptyList[Transformation]]): Context[Asset] =
     (for {
       transformation <- item
-      context = transformation.map { t =>
-        val asset: Asset = rewrite(t)
-        asset.assetRef -> asset
+      context = transformation.toList.flatMap {
+        case s: SplitT =>
+          val passAsset = Asset(s.split.pass, Source.Where(s.split.from, s.split.condition))
+          val failAsset =
+            Asset(s.split.fail, Source.Where(s.split.from, s"NOT (${s.split.condition})"))
+          List(passAsset.assetRef -> passAsset, failAsset.assetRef -> failAsset)
+        case t =>
+          val asset: Asset = rewrite(t)
+          List(asset.assetRef -> asset)
       }
-    } yield context.toList.toMap).getOrElse(Map())
+    } yield context.toMap).getOrElse(Map())
 
   def rewrite(item: ETL): Context[Asset] =
     icontext(item.input) ++ ocontext(item.output) ++ tcontext(item.transformation)


### PR DESCRIPTION
## Summary
- Adds `Split` transformation: splits a DataFrame into pass/fail branches based on a condition
- Implemented as serializer-level sugar — expands to two `Where` transformations at rewrite time
- No model or semantic changes needed
- Enables dead letter pattern

Closes #56