### PR TITLE
infra: add Dockerfile and docker-compose for easy deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+target/
+.git/
+.github/
+.idea/
+.bsp/
+.metals/
+.claude/
+*.class

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,11 @@ jobs:
         with:
           name: test-results-java-${{ matrix.java }}
           path: target/test-reports
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build -t teckel:test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:11-jre AS builder
+
+# Install sbt
+RUN apt-get update && apt-get install -y curl && \
+    curl -fsSL "https://github.com/sbt/sbt/releases/download/v1.10.7/sbt-1.10.7.tgz" | tar xz -C /opt && \
+    ln -s /opt/sbt/bin/sbt /usr/local/bin/sbt
+
+WORKDIR /build
+COPY . .
+RUN sbt cli/assembly
+
+FROM apache/spark:3.5.5-java11
+USER root
+
+COPY --from=builder /build/cli/target/scala-2.13/teckel-etl_2.13.jar /opt/teckel/teckel-etl.jar
+
+ENTRYPOINT ["/opt/spark/bin/spark-submit", "--class", "com.eff3ct.teckel.app.Main", "/opt/teckel/teckel-etl.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  teckel:
+    build: .
+    volumes:
+      - ./data:/data
+      - ./docs/etl:/etl
+    command: ["-f", "/etl/simple.yaml"]


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile: builds uber JAR then uses `apache/spark:3.5.5-java11` runtime
- docker-compose for local development
- Docker build verification in CI

Closes #50