### PR TITLE
fix: replace mutable Map with ConcurrentHashMap for thread-safe state

### DIFF
--- a/model/src/main/scala/com/eff3ct/teckel/model/package.scala
+++ b/model/src/main/scala/com/eff3ct/teckel/model/package.scala
@@ -23,7 +23,8 @@
  */
 
 package com.eff3ct.teckel
-import scala.collection.mutable.{Map => MMap}
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters._
 
 package object model {
 
@@ -33,8 +34,11 @@ package object model {
   type Mode       = String
   type Options    = Map[String, String]
   type Context[T] = Map[AssetRef, T]
-  // TODO. Use a Effect Mutable State to keep track of the already evaluated assets
-  type Mutex[T] = MMap[AssetRef, T]
+  type Mutex[T]   = scala.collection.concurrent.Map[AssetRef, T]
+
+  object Mutex {
+    def empty[T]: Mutex[T] = new ConcurrentHashMap[AssetRef, T]().asScala
+  }
 
   type Column       = String
   type Condition    = String

--- a/semantic/src/main/scala/com/eff3ct/teckel/semantic/evaluation.scala
+++ b/semantic/src/main/scala/com/eff3ct/teckel/semantic/evaluation.scala
@@ -30,8 +30,6 @@ import com.eff3ct.teckel.semantic.core._
 import com.eff3ct.teckel.semantic.sources._
 import org.apache.spark.sql._
 
-import scala.collection.mutable.{Map => MMap}
-
 object evaluation {
 
   private def register(
@@ -45,7 +43,7 @@ object evaluation {
 
   implicit def debug(implicit S: SparkSession): EvalAsset[DataFrame] =
     new EvalAsset[DataFrame] {
-      val global: Mutex[DataFrame] = MMap()
+      val global: Mutex[DataFrame] = Mutex.empty[DataFrame]
       override def eval(context: Context[Asset], asset: Asset): DataFrame = {
         val registerCallBack: DataFrame => DataFrame     = register(global, asset, _)
         val getTableCallBack: Asset => Option[DataFrame] = a => global.get(a.assetRef)


### PR DESCRIPTION
## Summary
- Replaces `scala.collection.mutable.Map` with `ConcurrentHashMap`-backed concurrent map
- Removes the TODO about Effect-based mutable state
- Thread-safe without changing trait signatures

Closes #37