### PR TITLE
fix: resolve compilation errors across modules

### DIFF
--- a/cli/src/main/scala/com/eff3ct/teckel/app/Main.scala
+++ b/cli/src/main/scala/com/eff3ct/teckel/app/Main.scala
@@ -42,7 +42,7 @@ object Main extends SparkETL {
   )(implicit spark: SparkSession, logger: slf4j.Logger): IO[ExitCode] = {
     val commands = Console.parseCommand(args)
     commands match {
-      case Console.FILE(file, true) =>
+      case Console.FILE(file, _, true, _) =>
         // Dry run mode
         IO {
           val content = scala.io.Source.fromFile(file).mkString

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -7,7 +7,7 @@ object Version {
   lazy val Cats: String       = "2.13.0"
   lazy val CatsEffect: String = "3.5.7"
 
-  lazy val CirceYaml   = "1.16.0"
+  lazy val CirceYaml   = "1.15.0"
   lazy val Circe       = "0.14.10"
   lazy val Fs2: String = "3.11.0"
 

--- a/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
+++ b/semantic/src/main/scala/com/eff3ct/teckel/semantic/sources/Debug.scala
@@ -130,6 +130,8 @@ object Debug {
     others.foreach { case (name, otherDf) => otherDf.createOrReplaceTempView(name) }
     df.createOrReplaceTempView(source.assetRef)
     S.sql(source.query)
+  }
+
   /** Union */
   def union[S <: Union](source: S, df: DataFrame, context: Context[DataFrame]): DataFrame = {
     val otherDfs = source.others.map(ref => context(ref))

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/operations.scala
@@ -69,10 +69,10 @@ object operations {
       Decoder[DropColumnsOp].widen,
       Decoder[RenameColumnsOp].widen,
       Decoder[CastColumnsOp].widen,
-      Decoder[SqlOp].widen
+      Decoder[SqlOp].widen,
       Decoder[UnionOp].widen,
       Decoder[IntersectOp].widen,
-      Decoder[ExceptOp].widen
+      Decoder[ExceptOp].widen,
       Decoder[WindowOp].widen,
       Decoder[FlattenOp].widen,
       Decoder[SplitOp].widen

--- a/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/serializer/model/transformation.scala
@@ -68,10 +68,10 @@ object transformation {
       Decoder[DropColumns].widen,
       Decoder[RenameColumns].widen,
       Decoder[CastColumns].widen,
-      Decoder[SqlExpr].widen
+      Decoder[SqlExpr].widen,
       Decoder[UnionT].widen,
       Decoder[IntersectT].widen,
-      Decoder[ExceptT].widen
+      Decoder[ExceptT].widen,
       Decoder[WindowT].widen,
       Decoder[FlattenT].widen,
       Decoder[SplitT].widen

--- a/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
+++ b/serializer/src/main/scala/com/eff3ct/teckel/transform/Rewrite.scala
@@ -122,6 +122,8 @@ object Rewrite {
     Asset(
       item.name,
       Source.Except(item.except.left, item.except.right, item.except.all.getOrElse(false))
+    )
+
   def rewriteOp(item: FlattenT): Asset =
     Asset(item.name, Source.Flatten(item.flatten.from, item.flatten.separator, item.flatten.explodeArrays))
 
@@ -155,6 +157,7 @@ object Rewrite {
       case s: ExceptT       => rewriteOp(s)
       case s: WindowT       => rewriteOp(s)
       case s: FlattenT      => rewriteOp(s)
+      case _: SplitT        => throw new IllegalStateException("SplitT is expanded in tcontext")
     }
 
   def icontext(item: NonEmptyList[Input]): Context[Asset] =


### PR DESCRIPTION
## Summary
- Fix circe-yaml version 1.16.0 → 1.15.0 (version does not exist on Maven Central)
- Add missing commas in Circe decoder lists (operations.scala, transformation.scala)
- Add missing closing brace in `Debug.sql` method
- Add missing closing paren in `Rewrite.rewriteOp(ExceptT)`
- Fix `Main.scala` FILE pattern match to match 4-field case class
- Add exhaustive `SplitT` case in `Rewrite.rewrite` match

## Test plan
- [x] `sbt compile` passes successfully
- [ ] CI green